### PR TITLE
remove dart:io import

### DIFF
--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -8,10 +8,10 @@
  */
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:fluro/fluro.dart';
 import 'package:fluro/src/common.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -127,7 +127,7 @@ class Router {
       bool isNativeTransition = (transition == TransitionType.native ||
           transition == TransitionType.nativeModal);
       if (isNativeTransition) {
-        if (Platform.isIOS) {
+        if (Theme.of(buildContext).platform == TargetPlatform.iOS) {
           return CupertinoPageRoute<dynamic>(
               settings: routeSettings,
               fullscreenDialog: transition == TransitionType.nativeModal,


### PR DESCRIPTION
fluro does not work in web apps because it has `dart:io` import.
This PR replaces `Platform.isIOS` condition with `Theme.platform`, and removes 'dart:io' import.